### PR TITLE
Gaga: Creacion de 2 Bind y carpeta con DCLGEN

### DIFF
--- a/BIND/BPKSNPR4.TXT
+++ b/BIND/BPKSNPR4.TXT
@@ -1,0 +1,11 @@
+DSN    SYSTEM     (DSN1)                                                00010005
+BIND   PACKAGE    (PKNOTAS)  -                                          00020010
+       MEMBER     (PSNNPR04) -                                          00030011
+       ACTION     (REPLACE)  -                                          00040009
+       ISOLATION  (CS)       -                                          00050009
+       VALIDATE   (BIND)     -                                          00060009
+       RELEASE    (COMMIT)   -                                          00070009
+       OWNER      (P390)     -                                          00080009
+       QUALIFIER  (P390)                                                00090008
+END                                                                     00100005
+

--- a/BIND/BPKSNUS2.TXT
+++ b/BIND/BPKSNUS2.TXT
@@ -1,0 +1,11 @@
+DSN    SYSTEM     (DSN1)                                                00010005
+BIND   PACKAGE    (PKNOTAS)  -                                          00020011
+       MEMBER     (RENUSUA2) -                                          00030010
+       ACTION     (REPLACE)  -                                          00040011
+       ISOLATION  (CS)       -                                          00050011
+       VALIDATE   (BIND)     -                                          00060011
+       RELEASE    (COMMIT)   -                                          00070011
+       OWNER      (P390)     -                                          00080011
+       QUALIFIER  (P390)                                                00090008
+END                                                                     00100005
+

--- a/DCLGEN/CURSOS.TXT
+++ b/DCLGEN/CURSOS.TXT
@@ -1,0 +1,39 @@
+      ******************************************************************
+      * DCLGEN TABLE(CURSOS)                                           *
+      *        LIBRARY(P390.DB2.DCLGEN(CURSOS))                        *
+      *        ACTION(REPLACE)                                         *
+      *        LANGUAGE(COBOL)                                         *
+      *        NAMES(CR-)                                              *
+      *        STRUCTURE(CR-CURSOS)                                    *
+      *        QUOTE                                                   *
+      *        LABEL(YES)                                              *
+      *        DBCSDELIM(NO)                                           *
+      *        COLSUFFIX(YES)                                          *
+      * ... IS THE DCLGEN COMMAND THAT MADE THE FOLLOWING STATEMENTS   *
+      ******************************************************************
+           EXEC SQL DECLARE CURSOS TABLE
+           ( CURSO                          CHAR(5) NOT NULL,
+             DESCRIPCION                    CHAR(20) NOT NULL,
+             DNIPROFESOR                    CHAR(9) NOT NULL,
+             ESTADO                         CHAR(1) NOT NULL
+           ) END-EXEC.
+      ******************************************************************
+      * COBOL DECLARATION FOR TABLE CURSOS                             *
+      ******************************************************************
+       01  CR-CURSOS.
+      *    *************************************************************
+      *                       CURSO
+           10 CR-CURSO             PIC X(5).
+      *    *************************************************************
+      *                       DESCRIPCION
+           10 CR-DESCRIPCION       PIC X(20).
+      *    *************************************************************
+      *                       DNIPROFESOR
+           10 CR-DNIPROFESOR       PIC X(9).
+      *    *************************************************************
+      *                       ESTADO
+           10 CR-ESTADO            PIC X(1).
+      ******************************************************************
+      * THE NUMBER OF COLUMNS DESCRIBED BY THIS DECLARATION IS 4       *
+      ******************************************************************
+

--- a/DCLGEN/NOTASFIN.TXT
+++ b/DCLGEN/NOTASFIN.TXT
@@ -1,0 +1,39 @@
+      ******************************************************************
+      * DCLGEN TABLE(NOTASFIN)                                         *
+      *        LIBRARY(P390.DB2.DCLGEN(NOTASFIN))                      *
+      *        ACTION(REPLACE)                                         *
+      *        LANGUAGE(COBOL)                                         *
+      *        NAMES(NT-)                                              *
+      *        STRUCTURE(NT-NOTASFIN)                                  *
+      *        QUOTE                                                   *
+      *        LABEL(YES)                                              *
+      *        DBCSDELIM(NO)                                           *
+      *        COLSUFFIX(YES)                                          *
+      * ... IS THE DCLGEN COMMAND THAT MADE THE FOLLOWING STATEMENTS   *
+      ******************************************************************
+           EXEC SQL DECLARE NOTASFIN TABLE
+           ( CURSO                          CHAR(5) NOT NULL,
+             DNIESTUDIANTE                  CHAR(9) NOT NULL,
+             AAAA                           CHAR(4) NOT NULL,
+             NOTA                           DECIMAL(5, 2) NOT NULL
+           ) END-EXEC.
+      ******************************************************************
+      * COBOL DECLARATION FOR TABLE NOTASFIN                           *
+      ******************************************************************
+       01  NT-NOTASFIN.
+      *    *************************************************************
+      *                       CURSO
+           10 NT-CURSO             PIC X(5).
+      *    *************************************************************
+      *                       DNIESTUDIANTE
+           10 NT-DNIESTUDIANTE     PIC X(9).
+      *    *************************************************************
+      *                       AAAA
+           10 NT-AAAA              PIC X(4).
+      *    *************************************************************
+      *                       NOTA
+           10 NT-NOTA              PIC S9(3)V9(2) USAGE COMP-3.
+      ******************************************************************
+      * THE NUMBER OF COLUMNS DESCRIBED BY THIS DECLARATION IS 4       *
+      ******************************************************************
+

--- a/DCLGEN/PERFILES.TXT
+++ b/DCLGEN/PERFILES.TXT
@@ -1,0 +1,51 @@
+      ******************************************************************
+      * DCLGEN TABLE(PERFILES)                                         *
+      *        LIBRARY(P390.DB2.DCLGEN(PERFILES))                      *
+      *        ACTION(REPLACE)                                         *
+      *        LANGUAGE(COBOL)                                         *
+      *        NAMES(PF-)                                              *
+      *        STRUCTURE(PF-PERFILES)                                  *
+      *        QUOTE                                                   *
+      *        LABEL(YES)                                              *
+      *        DBCSDELIM(NO)                                           *
+      *        COLSUFFIX(YES)                                          *
+      * ... IS THE DCLGEN COMMAND THAT MADE THE FOLLOWING STATEMENTS   *
+      ******************************************************************
+           EXEC SQL DECLARE PERFILES TABLE
+           ( TRAN                           CHAR(4) NOT NULL,
+             IDPERFIL                       CHAR(3) NOT NULL,
+             NOMBRE                         CHAR(20) NOT NULL,
+             CONSUL                         CHAR(2) NOT NULL,
+             BORRAR                         CHAR(2) NOT NULL,
+             INGRESAR                       CHAR(2) NOT NULL,
+             MODIF                          CHAR(2) NOT NULL
+           ) END-EXEC.
+      ******************************************************************
+      * COBOL DECLARATION FOR TABLE PERFILES                           *
+      ******************************************************************
+       01  PF-PERFILES.
+      *    *************************************************************
+      *                       TRAN
+           10 PF-TRAN              PIC X(4).
+      *    *************************************************************
+      *                       IDPERFIL
+           10 PF-IDPERFIL          PIC X(3).
+      *    *************************************************************
+      *                       NOMBRE
+           10 PF-NOMBRE            PIC X(20).
+      *    *************************************************************
+      *                       CONSUL
+           10 PF-CONSUL            PIC X(2).
+      *    *************************************************************
+      *                       BORRAR
+           10 PF-BORRAR            PIC X(2).
+      *    *************************************************************
+      *                       INGRESAR
+           10 PF-INGRESAR          PIC X(2).
+      *    *************************************************************
+      *                       MODIF
+           10 PF-MODIF             PIC X(2).
+      ******************************************************************
+      * THE NUMBER OF COLUMNS DESCRIBED BY THIS DECLARATION IS 7       *
+      ******************************************************************
+

--- a/DCLGEN/PERMISOS.TXT
+++ b/DCLGEN/PERMISOS.TXT
@@ -1,0 +1,47 @@
+      ******************************************************************
+      * DCLGEN TABLE(PERMISOS)                                         *
+      *        LIBRARY(P390.DB2.DCLGEN(PERMISOS))                      *
+      *        ACTION(REPLACE)                                         *
+      *        LANGUAGE(COBOL)                                         *
+      *        NAMES(PM-)                                              *
+      *        STRUCTURE(PM-PERMISOS)                                  *
+      *        QUOTE                                                   *
+      *        LABEL(YES)                                              *
+      *        DBCSDELIM(NO)                                           *
+      *        COLSUFFIX(YES)                                          *
+      * ... IS THE DCLGEN COMMAND THAT MADE THE FOLLOWING STATEMENTS   *
+      ******************************************************************
+           EXEC SQL DECLARE PERMISOS TABLE
+           ( TRAN                           CHAR(4) NOT NULL,
+             DNI                            CHAR(9) NOT NULL,
+             IDPERFIL                       CHAR(3) NOT NULL,
+             NROACCESOS                     INTEGER NOT NULL,
+             FECHAUL                        CHAR(10) NOT NULL,
+             HORAUL                         CHAR(8) NOT NULL
+           ) END-EXEC.
+      ******************************************************************
+      * COBOL DECLARATION FOR TABLE PERMISOS                           *
+      ******************************************************************
+       01  PM-PERMISOS.
+      *    *************************************************************
+      *                       TRAN
+           10 PM-TRAN              PIC X(4).
+      *    *************************************************************
+      *                       DNI
+           10 PM-DNI               PIC X(9).
+      *    *************************************************************
+      *                       IDPERFIL
+           10 PM-IDPERFIL          PIC X(3).
+      *    *************************************************************
+      *                       NROACCESOS
+           10 PM-NROACCESOS        PIC S9(9) USAGE COMP.
+      *    *************************************************************
+      *                       FECHAUL
+           10 PM-FECHAUL           PIC X(10).
+      *    *************************************************************
+      *                       HORAUL
+           10 PM-HORAUL            PIC X(8).
+      ******************************************************************
+      * THE NUMBER OF COLUMNS DESCRIBED BY THIS DECLARATION IS 6       *
+      ******************************************************************
+

--- a/DCLGEN/USUARIOS.TXT
+++ b/DCLGEN/USUARIOS.TXT
@@ -1,0 +1,55 @@
+      ******************************************************************
+      * DCLGEN TABLE(USUARIOS)                                         *
+      *        LIBRARY(P390.DB2.DCLGEN(USUARIOS))                      *
+      *        ACTION(REPLACE)                                         *
+      *        LANGUAGE(COBOL)                                         *
+      *        NAMES(US-)                                              *
+      *        STRUCTURE(US-USUARIOS)                                  *
+      *        QUOTE                                                   *
+      *        LABEL(YES)                                              *
+      *        DBCSDELIM(NO)                                           *
+      *        COLSUFFIX(YES)                                          *
+      * ... IS THE DCLGEN COMMAND THAT MADE THE FOLLOWING STATEMENTS   *
+      ******************************************************************
+           EXEC SQL DECLARE USUARIOS TABLE
+           ( DNI                            CHAR(9) NOT NULL,
+             TIPOUSUA                       CHAR(5) NOT NULL,
+             CLAVE                          CHAR(8) NOT NULL,
+             NOMBRE                         CHAR(20) NOT NULL,
+             APELLIDOS                      CHAR(20) NOT NULL,
+             DIRECCION                      CHAR(35) NOT NULL,
+             CARGO                          CHAR(20) NOT NULL,
+             ESTADO                         CHAR(1) NOT NULL
+           ) END-EXEC.
+      ******************************************************************
+      * COBOL DECLARATION FOR TABLE USUARIOS                           *
+      ******************************************************************
+       01  US-USUARIOS.
+      *    *************************************************************
+      *                       DNI
+           10 US-DNI               PIC X(9).
+      *    *************************************************************
+      *                       TIPOUSUA
+           10 US-TIPOUSUA          PIC X(5).
+      *    *************************************************************
+      *                       CLAVE
+           10 US-CLAVE             PIC X(8).
+      *    *************************************************************
+      *                       NOMBRE
+           10 US-NOMBRE            PIC X(20).
+      *    *************************************************************
+      *                       APELLIDOS
+           10 US-APELLIDOS         PIC X(20).
+      *    *************************************************************
+      *                       DIRECCION
+           10 US-DIRECCION         PIC X(35).
+      *    *************************************************************
+      *                       CARGO
+           10 US-CARGO             PIC X(20).
+      *    *************************************************************
+      *                       ESTADO
+           10 US-ESTADO            PIC X(1).
+      ******************************************************************
+      * THE NUMBER OF COLUMNS DESCRIBED BY THIS DECLARATION IS 8       *
+      ******************************************************************
+


### PR DESCRIPTION
Sep 29 - Gabriel Gallego

Se creo carpeta DCLGEN con las tablas de la base de datos para quienes no pueden generarla en el 390 con las tablas de:
- USUARIOS
- PERMISOS
- PERFILES
- CURSOS
- NOTAS
Se actualizo carpeta de BIND con:
- BPKSNUS2  Programa 2 encapsulador de Usuarios que se usa en el CRUD de Estudiantes
- BPKSNPR4  Programa que consulta las notas de los estudiantes de los cursos de un profesor que utiliza DB2